### PR TITLE
Add JSON parse errors in DecodeFailure cause

### DIFF
--- a/play-json/src/main/scala/org/http4s/play/Parser.scala
+++ b/play-json/src/main/scala/org/http4s/play/Parser.scala
@@ -24,7 +24,7 @@ package org.http4s.play
 
 import org.typelevel.jawn.Facade
 import org.typelevel.jawn.SupportParser
-import play.api.libs.json._
+import play.api.libs.json.*
 
 private[play] object Parser extends SupportParser[JsValue] {
 

--- a/play-json/src/main/scala/org/http4s/play/PlayJsonDecodingFailure.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayJsonDecodingFailure.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.play
+
+import cats.Show
+import play.api.libs.json.JsPath
+import play.api.libs.json.JsonValidationError
+
+final case class PlayJsonDecodingFailure(path: JsPath, error: JsonValidationError)
+    extends Exception {
+  override def fillInStackTrace(): Throwable = this
+
+  def message: Option[String] =
+    error match {
+      case JsonValidationError.Detailed(msg, arg) => Some(s"$msg ($arg)")
+      case JsonValidationError.Message(msg) => Some(msg)
+      case _ => None
+    }
+
+  def pathToRootString: String = path.path.foldLeft("")((acc, p) => acc + p.toJsonString)
+
+  override def toString: String =
+    message.fold(s"PlayJsonDecodingFailure at $pathToRootString")(msg =>
+      s"PlayJsonDecodingFailure at $pathToRootString: $msg"
+    )
+}
+
+object PlayJsonDecodingFailure {
+
+  /** Creates compact, human readable string representations for PlayJsonDecodingFailure
+    * Cursor history is represented as JS style selections, i.e. ".foo.bar[3]"
+    */
+  implicit final val showDecodingFailure: Show[PlayJsonDecodingFailure] =
+    Show.fromToString
+}

--- a/play-json/src/main/scala/org/http4s/play/PlayJsonDecodingFailures.scala
+++ b/play-json/src/main/scala/org/http4s/play/PlayJsonDecodingFailures.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.play
+
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import play.api.libs.json.JsPath
+import play.api.libs.json.JsonValidationError
+
+final case class PlayJsonDecodingFailures(failures: NonEmptyList[PlayJsonDecodingFailure])
+    extends Exception {
+  override def getMessage: String = failures.iterator.map(_.show).mkString("\n")
+}
+
+object PlayJsonDecodingFailures {
+  def fromJsResult(
+      errors: scala.collection.Seq[(JsPath, scala.collection.Seq[JsonValidationError])]
+  ): PlayJsonDecodingFailures =
+    PlayJsonDecodingFailures(
+      errors.toList
+        .flatMap {
+          case (path, Nil) =>
+            List(PlayJsonDecodingFailure(path, JsonValidationError("error.path.missing")))
+          case (path, errors) => errors.toList.map(PlayJsonDecodingFailure(path, _))
+        }
+        .toNel
+        .getOrElse(
+          NonEmptyList.one(
+            PlayJsonDecodingFailure(JsPath, JsonValidationError("error.path.missing"))
+          )
+        )
+    )
+}


### PR DESCRIPTION
Fixes #81

Uses the same implementation as http4s-circe to add JSON parse errors as the cause of the DecodeFailure