### PR TITLE
Scala 2.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ ThisBuild / githubWorkflowJavaVersions := List("11", "17", "21").map(JavaSpec.te
 ThisBuild / tlJdkRelease := Some(11)
 
 val Scala212 = "2.12.19"
-val Scala213 = "2.13.12"
+val Scala213 = "2.13.13"
 val Scala3 = "3.3.3"
 ThisBuild / scalaVersion := Scala213
 ThisBuild / crossScalaVersions := Seq(Scala212, Scala213, Scala3)


### PR DESCRIPTION
We can't go to 2.13.14 until our semanticdb dependency gets bumped (munit-scalacheck?) - so go to 2.13.13 for now to unblock other dependency bumps